### PR TITLE
feat: default taskfile.yml for global

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,28 @@
 - [Task](https://taskfile.dev/)
 - 2025-09-16 v3.45.3 のリリースで `$XDG_CONFIG_HOME/task/taskrc.yml` が使用可能になったのでテスト
 
+# usage
+
+```bash
+cd ~/.config  # $XDG_CONFIG_HOME or $HOME/.config
+git clone https://github.com/officel/config_task.git ./task
+
+# or I do it this way
+cd ~/repos/github.com/officel/
+git clone https://github.com/officel/config_task.git
+ln -s ~/repos/github.com/officel/config_task/ ~/.config/task
+```
+
+using global tasks, copy them (of course, it's up to you).
+
+```bash
+cd
+ln -s ~/.config/task/Taskfile.yml
+
+alias t='task'
+t
+```
+
 # related my projects
 
 - [officel/config_aqua: .config/aqua](https://github.com/officel/config_aqua)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+# vars:
+
+tasks:
+  default:
+    cmds:
+      - echo "This is {{.TASKFILE}}"
+      - task --list --sort alphanumeric -t {{.TASKFILE}}
+    silent: true
+
+  vars:env:
+    desc: show environment variables
+    aliases:
+      - ve
+    cmds:
+      - echo "HOME={{.HOME}}"
+      - echo "PWD={{.PWD}}"
+      - echo "SHELL={{.SHELL}}"
+      - echo "USER={{.USER}}"
+    silent: true
+
+  vars:special:cli:
+    desc: show special variables cli
+    aliases:
+      - vsc
+    cmds:
+      - echo "CLI_ARGS={{.CLI_ARGS}}"
+      - echo "CLI_ARGS_LIST={{.CLI_ARGS_LIST}}"
+      - echo "CLI_FORCE={{.CLI_FORCE}}"
+      - echo "CLI_SILENT={{.CLI_SILENT}}"
+      - echo "CLI_VERBOSE={{.CLI_VERBOSE}}"
+      - echo "CLI_OFFLINE={{.CLI_OFFLINE}}"
+    silent: true
+
+  vars:special:task:
+    desc: show special variables task
+    aliases:
+      - vst
+    cmds:
+      - echo "TASK={{.TASK}}"
+      - echo "ALIAS={{.ALIAS}}"
+      - echo "TASK_EXE={{.TASK_EXE}}"
+    silent: true
+
+  vars:special:path:
+    desc: show special variables
+    aliases:
+      - vsp
+    cmds:
+      - echo "ROOT_TASKFILE={{.ROOT_TASKFILE}}"
+      - echo "ROOT_DIR={{.ROOT_DIR}}"
+      - echo "TASKFILE={{.TASKFILE}}"
+      - echo "TASKFILE_DIR={{.TASKFILE_DIR}}"
+      - echo "TASK_DIR={{.TASK_DIR}}"
+      - echo "USER_WORKING_DIR={{.USER_WORKING_DIR}}"
+    silent: true
+
+  task:init:
+    desc: alternative task --init
+    summary: |
+      see https://github.com/go-task/task/issues/2012
+      This task is an alternative to `task --init`.
+      maybe `task -g new`
+    aliases:
+      - new
+    vars:
+      MY_INIT_TASKFILE:
+        sh: curl -sSL https://raw.githubusercontent.com/officel/config_task/refs/heads/main/Taskfile.yml
+      EXPORT_FILE_NAME: taskfile.yaml
+    cmds:
+      - echo "{{.MY_INIT_TASKFILE}}" > {{.USER_WORKING_DIR}}/{{.EXPORT_FILE_NAME}}
+      - echo "exported to {{.USER_WORKING_DIR}}/{{.EXPORT_FILE_NAME}}"
+      - cat {{.USER_WORKING_DIR}}/{{.EXPORT_FILE_NAME}}

--- a/taskrc.yml
+++ b/taskrc.yml
@@ -1,7 +1,7 @@
 # https://taskfile.dev/docs/reference/config
 
 # Global settings
-verbose: true
+verbose: false
 concurrency: 2
 
 # Enable experimental features


### PR DESCRIPTION
- ~/.config/task に設定がおけるようになったのでこのリポジトリを置いた
- -g でのデフォルトタスクファイルもここから読んでくれたらいいのに、それはやってないようだ
- https://github.com/go-task/task/issues/2012 の代替案で、こういうリポジトリからファイル読み込んで展開すれば --init を使う必要もない
- もっとも、個人的には --init なんて最初のころしか使ってない。普段はベースのこぴぺ
- このリポジトリにタスクファイルの小ネタを集めておくといいかもしれないとか思っている